### PR TITLE
Error message says n>4 but means n>=4

### DIFF
--- a/hyperop/hyperop.py
+++ b/hyperop/hyperop.py
@@ -1,6 +1,6 @@
 from functools import reduce
 
-_errmsg_non_integral = "{} is not integral, required for hyperop n>4"
+_errmsg_non_integral = "{} is not an integer, required for hyperop n≥4"
 _errmsg_invalid_hyperop_n = "hyperoperators must be integers n>=0, " "created with n={}"
 
 # Define the base of the recursion, H0 the successor function


### PR DESCRIPTION
old:  3.14 is not integral, required for hyperop n>4
new:  3.14 is not an integer, required for hyperop n≥4

As a non-native speaker I also stumbled over "integral", I think "integer" is the clearer and more well known word here.